### PR TITLE
Enforced User ID is cast to INT in DTO

### DIFF
--- a/Resources/MoEngageDTO.py
+++ b/Resources/MoEngageDTO.py
@@ -1,7 +1,7 @@
 class MoEngageUserPropertyDTO:
     
     def __init__(self, user_id: int, first_campaign: str, first_network: str):
-        self.user_id = user_id
+        self.user_id = int(user_id)
         self.signup_event = 'Signup_stage1'
         self.first_campaign = first_campaign
         self.first_network = first_network
@@ -35,7 +35,7 @@ class MoEngageUserPropertyDTO:
 class MoEngageEventDTO:
 
     def __init__(self, user_id: int, event: str, event_campaign: str, event_network: str):
-        self.user_id = user_id
+        self.user_id = int(user_id)
         self.event = event
         self.event_campaign = event_campaign
         self.event_network = event_network


### PR DESCRIPTION
Enforced data type of User ID to be cast to `int` instead of pandas `float64`