### PR TITLE
Added Actual Event Creation/Trigger Time in DTO

### DIFF
--- a/ETL/Load/MoEngageEventLoader.py
+++ b/ETL/Load/MoEngageEventLoader.py
@@ -105,7 +105,8 @@ class MoEngageEventLoader(Loader):
                 user_id=row['[userId]'],
                 event=event,
                 event_campaign=campaign,
-                event_network=network
+                event_network=network,
+                time=row['{created_at}']
             )
             event_list.append(event_obj)
         return event_list

--- a/Resources/MoEngageDTO.py
+++ b/Resources/MoEngageDTO.py
@@ -34,11 +34,12 @@ class MoEngageUserPropertyDTO:
 
 class MoEngageEventDTO:
 
-    def __init__(self, user_id: int, event: str, event_campaign: str, event_network: str):
+    def __init__(self, user_id: int, event: str, event_campaign: str, event_network: str, time: int):
         self.user_id = int(user_id)
         self.event = event
         self.event_campaign = event_campaign
         self.event_network = event_network
+        self.time = time
 
     def to_moengage_dict(self):
         return dict(
@@ -51,7 +52,8 @@ class MoEngageEventDTO:
                         "Event": self.event,
                         "Campaign": self.event_campaign,
                         "Network": self.event_network
-                    }
+                    },
+                    current_time=self.time,
                 )
             ]
         )


### PR DESCRIPTION
Updated the MoEngage Event DTO to also pass UTC time for when event was triggered by the user.